### PR TITLE
!$ instead of # in pragma omp barrier; line 11

### DIFF
--- a/Book/Fortran/Fig_4.12_bar_Fortran
+++ b/Book/Fortran/Fig_4.12_bar_Fortran
@@ -8,7 +8,7 @@ call omp_set_num_threads(8)
    nthrds = omp_get_num_threads()
    if (id == 1) numthrds = nthrds  
    Arr(id) = lots_of_work(id, nthrds)
-#pragma omp barrier
+!$pragma omp barrier
    Brr(id) = needs_all_of_Arr(id, nthrds, Arr)
 !$omp end parallel
 


### PR DESCRIPTION
re : Fig_4.12_bar_Fortran (code snippet), line 11

#pragma wont work in omp Fortran, updated to !$pragma