### PR TITLE
Created and Initialized NTHREADS

### DIFF
--- a/Book/Fortran/Fig_5.9_piloop.f90
+++ b/Book/Fortran/Fig_5.9_piloop.f90
@@ -2,8 +2,9 @@
           USE OMP_LIB
           IMPLICIT NONE
 
-          INTEGER :: i, id, nthreads
+          INTEGER :: i, id
           INTEGER, PARAMETER :: num_steps=100000000
+          INTEGER :: NTHREADS = 4
           REAL*8 :: x, pi, sum, step
           REAL*8 :: start_time, run_time
 


### PR DESCRIPTION
**Fig_5.9_piloop.f90**

on line 15, **OMP_SET_NUM_THREADS** is passed **NTHREADS**, not **nthreads**

hence, **NTHREADS** was created/initialized on line 7, and **nthreads** was removed from line 5

now the code runs and prints **"pi is      3.14159263 in    0.432 secs"**